### PR TITLE
Removed XDebug 2 

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,11 @@
 
 This document contains all the info needed for upgrades of Major releases.
 
+# 4.0
+
+XDebug 2 config was removed. If you still need to run XDebug 2 for some reason use the resource to install a custom config. XDebug is now not installed
+for CLI anymore since it's easy to enable it if needed and this removes the performance hit when running CLI tools (e.g. composer).
+
 # 3.4
 Support for XDebug 3 was added. This just means that `xdebug.mode=debug,develop` is now set in addition to the XDebug2 settings. This should enable
 the same behaviour as before. This also means that XDebug is also active on CLI. This will change with the next major release.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ The recicpies are now depcracted and will be removed with the next major release
 
 This also means that the attributes will be removed as well since they are only used in the recipies.
 
-As of 3.4 XDebug 2 is also deprecated. Config was added for XDebug 3 so upgrading should already work. The XDebug 2 configs will be removed with the
-next major release.
-
 ## Usage
 
 Create a wrapper cookbook and add this cookbook to your Berksfile/Metadata.
@@ -167,7 +164,7 @@ This resource can be used to install xdebug with a default configuraiton.
 - `config_cookbook_file`: The cookbook file that will be used as config, default: `xdebug.ini`
 - `config_cookbook_file_cookbook`: The cookbook the cookbook file will be taken from, default: `codenamephp_php`
 - `add_sury_repository`: If the sury repository should be added, default: `true`
-- `services`: The services the config should be managed for, default: `['cli', 'apache2', 'fpm']`
+- `services`: The services the config should be managed for, default: `['apache2', 'fpm']`
 
 #### Examples
 ```ruby
@@ -196,8 +193,5 @@ Keep in mind that if you set these to false, you need to install the dependencie
 The default cookbook is a No-Op since you want to choose your PHP version and stick to it. Having the default cookbook to install some "random" version could lead
 to unexpected updates and would cause more breaking changes.
 
-[apache2_github]: https://github.com/sous-chefs/apache2
-[apt_github]: https://github.com/chef-cookbooks/apt
-[chef.cookbook.apache2_github]: https://github.com/codenamephp/chef.cookbook.apache2
 [sury_url]: https://deb.sury.org/
 [phive_url]: https://phar.io

--- a/files/default/xdebug.ini
+++ b/files/default/xdebug.ini
@@ -1,17 +1,2 @@
 [XDebug]
-xdebug.profiler_append = 0
-xdebug.profiler_enable = 0
-xdebug.profiler_enable_trigger = 1
-xdebug.profiler_output_dir = "/var/log/xdebug/profiler"
-xdebug.profiler_output_name = "%p.%t.callgrind"
-xdebug.remote_enable = 1
-xdebug.remote_handler = "dbgp"
-xdebug.remote_host = "localhost"
-xdebug.remote_mode = "req"
-xdebug.remote_port = 9000
-xdebug.trace_enable_trigger = 1
-xdebug.var_display_max_data = 50000
-xdebug.var_display_max_depth = 10
-
-; xdebug3
 xdebug.mode=debug,develop

--- a/resources/phive.rb
+++ b/resources/phive.rb
@@ -31,7 +31,7 @@ action :install do
   end
 
   execute 'verify downloaded phar' do
-    command "gpg --keyserver pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79 && gpg --verify #{new_resource.key_path} #{new_resource.binary_tmp_path}"
+    command "gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79 && gpg --verify #{new_resource.key_path} #{new_resource.binary_tmp_path}"
     action :nothing
     notifies :create, 'file[move binary from tmp to final path]', :immediately
   end

--- a/resources/xdebug.rb
+++ b/resources/xdebug.rb
@@ -6,7 +6,7 @@ property :config_name, String, default: 'xdebug-custom.ini', description: 'The c
 property :config_cookbook_file, String, default: 'xdebug.ini', description: 'The name of the cookbook file of the config'
 property :config_cookbook_file_cookbook, String, default: 'codenamephp_php', description: 'The name of the cookbook the cookbook file will be taken from'
 property :add_sury_repository, [true, false], default: true, description: 'Flag if the sury repository should be added first'
-property :services, Array, default: %w(cli apache2 fpm), description: 'The services like cli and apache2 the config will be handled for'
+property :services, Array, default: %w(apache2 fpm), description: 'The services like cli and apache2 the config will be handled for'
 
 action :install do
   codenamephp_php_sury_repository 'sury-php' do

--- a/spec/unit/resources/phive_spec.rb
+++ b/spec/unit/resources/phive_spec.rb
@@ -44,7 +44,7 @@ describe 'codenamephp_php_phive' do
       expect(chef_run.remote_file('/tmp/phive.phar.asc')).to notify('execute[verify downloaded phar]').to(:run).immediately
 
       is_expected.to nothing_execute('verify downloaded phar').with(
-        command: 'gpg --keyserver pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79 && gpg --verify /tmp/phive.phar.asc /tmp/phive.phar'
+        command: 'gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79 && gpg --verify /tmp/phive.phar.asc /tmp/phive.phar'
       )
 
       expect(chef_run.execute('verify downloaded phar')).to notify('file[move binary from tmp to final path]').to(:create).immediately
@@ -94,7 +94,7 @@ describe 'codenamephp_php_phive' do
       )
 
       is_expected.to nothing_execute('verify downloaded phar').with(
-        command: 'gpg --keyserver pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79 && gpg --verify /some/key/path /some/temp/path'
+        command: 'gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79 && gpg --verify /some/key/path /some/temp/path'
       )
 
       is_expected.to nothing_file('move binary from tmp to final path').with(

--- a/spec/unit/resources/xdebug_spec.rb
+++ b/spec/unit/resources/xdebug_spec.rb
@@ -25,7 +25,7 @@ describe 'codenamephp_php_xdebug' do
         cookbook_file: 'xdebug.ini',
         config_name: 'xdebug-custom.ini',
         php_versions: %w(99 88),
-        services: %w(cli apache2 fpm)
+        services: %w(apache2 fpm)
       )
     }
   end
@@ -45,7 +45,7 @@ describe 'codenamephp_php_xdebug' do
         cookbook_file: 'xdebug.ini',
         config_name: 'xdebug-custom.ini',
         php_versions: %w(99 88),
-        services: %w(cli apache2 fpm)
+        services: %w(apache2 fpm)
       )
     }
   end


### PR DESCRIPTION
Removed XDebug 2 settings from config and only installing it for apache2 and fpm service to remove the performance hit when running CLI scripts.