### PR TITLE
Added php_version property to phive resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,30 @@ This resources installs [Phive][phive_url] as global command line tool
 - `key_uri`: The uri from where the key for verification will be downloaded, default: `'https://phar.io/releases/phive.phar.asc'`
 - `key_path`: The path to where the key will be downloaded to prior to verifcation, default: `'/tmp/phive.phar.asc'`
 - `install_php_dependencies`: Flag if the dependencies (php and some extensions) should be installed, default: true
-Keep in mind that if you set these to false, you need to install the dependencies yourself or Phive might not work
+  Keep in mind that if you set these to false, you need to install the dependencies yourself or Phive might not work
+- `php_version`: The desired php version that will be used when installing the dependencies. This is usesd as prefix, e.g. php7.4 -> php7.4-curl'
+  The 'php' is normalized so you can either pass 'phpX.X' or just 'X.X'
+
+#### Examples
+```ruby
+# Minimal config
+codenamephp_php_phive 'install phive'
+```
+
+```ruby
+# With custom php version
+codenamephp_php_phive 'install phive' do
+  php_version '8.0'
+end
+```
+
+```ruby
+# Without php dependencies
+codenamephp_php_phive 'install phive' do
+  install_php_dependencies false
+end
+```
+
 ## Default
 The default cookbook is a No-Op since you want to choose your PHP version and stick to it. Having the default cookbook to install some "random" version could lead
 to unexpected updates and would cause more breaking changes.

--- a/resources/phive.rb
+++ b/resources/phive.rb
@@ -10,7 +10,7 @@ property :install_php_dependencies, [true, false], default: true, description: '
 
 action :install do
   codenamephp_php_package 'install needed extensions' do
-    additional_packages %w(php-xml php-mbstring)
+    additional_packages %w(php-xml php-mbstring php-curl)
     only_if new_resource.install_php_dependencies.to_s
   end
 

--- a/resources/phive.rb
+++ b/resources/phive.rb
@@ -7,10 +7,11 @@ property :key_uri, String, default: 'https://phar.io/releases/phive.phar.asc', d
 property :key_path, String, default: '/tmp/phive.phar.asc', description: 'Local path to where the phive key is saved for verification'
 property :install_php_dependencies, [true, false], default: true, description: 'Phive needs php and some extensions to run.
   Set this to false if you want to install these yourself. If true, php, php-xml and php-mbstring will be installed.'
+property :php_version, String, default: 'php', description: 'The desired php version that will be used when installing the dependencies. This is usesd as prefix, e.g. php7.4 -> php7.4-curl'
 
 action :install do
   codenamephp_php_package 'install needed extensions' do
-    additional_packages %w(php-xml php-mbstring php-curl)
+    additional_packages get_dependency_package_names_with_php_version(%w(xml mbstring curl), new_resource.php_version)
     only_if new_resource.install_php_dependencies.to_s
   end
 
@@ -60,5 +61,11 @@ action :uninstall do
   file 'delete phive.phar from binary path' do
     path new_resource.binary_path
     action :delete
+  end
+end
+
+action_class do
+  def get_dependency_package_names_with_php_version(packages, php_version)
+    packages.map { |package| "php#{php_version.sub('php', '')}-#{package}" }
   end
 end

--- a/spec/unit/resources/phive_spec.rb
+++ b/spec/unit/resources/phive_spec.rb
@@ -83,10 +83,15 @@ describe 'codenamephp_php_phive' do
         source 'https://some/source/uri'
         key_uri 'https://some/key/uri'
         key_path '/some/key/path'
+        php_version '5.6'
       end
     end
 
     it {
+      is_expected.to install_codenamephp_php_package('install needed extensions').with(
+        additional_packages: %w(php5.6-xml php5.6-mbstring php5.6-curl)
+      )
+
       is_expected.to create_remote_file('/some/temp/path').with(
         source: 'https://some/source/uri'
       )
@@ -109,6 +114,26 @@ describe 'codenamephp_php_phive' do
 
       is_expected.to delete_file('delete tmp key').with(
         path: '/some/key/path'
+      )
+    }
+  end
+
+  context 'Install with php_version with php prefix' do
+    before(:example) do
+      stub_command('test -e /usr/bin/phive').and_return(false)
+      stub_command('test -e /tmp/phive.phar').and_return(true)
+      stub_command('true').and_return(true) # yeah, I don't know either ...
+    end
+
+    recipe do
+      codenamephp_php_phive 'phive' do
+        php_version 'php5.6'
+      end
+    end
+
+    it {
+      is_expected.to install_codenamephp_php_package('install needed extensions').with(
+        additional_packages: %w(php5.6-xml php5.6-mbstring php5.6-curl)
       )
     }
   end

--- a/spec/unit/resources/phive_spec.rb
+++ b/spec/unit/resources/phive_spec.rb
@@ -30,7 +30,7 @@ describe 'codenamephp_php_phive' do
 
     it {
       is_expected.to install_codenamephp_php_package('install needed extensions').with(
-        additional_packages: %w(php-xml php-mbstring)
+        additional_packages: %w(php-xml php-mbstring php-curl)
       )
 
       is_expected.to create_remote_file('/tmp/phive.phar').with(

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -11,11 +11,17 @@ codenamephp_php_package 'install php 7.4' do
   additional_packages %w(php7.4-fpm php7.4-curl php7.4-gd)
 end
 
+codenamephp_php_package 'install php 8.0' do
+  package_name 'php8.0-cli'
+end
+
 codenamephp_php_composer 'install composer'
 
 codenamephp_php_xdebug 'install xdebug' do
-  php_versions %w(5.6 7.4)
+  php_versions %w(5.6 7.4 8.0)
   services %w(cli fpm)
 end
 
-codenamephp_php_phive 'install phive'
+codenamephp_php_phive 'install phive' do
+  php_version '8.0'
+end

--- a/test/smoke/default/php_test.rb
+++ b/test/smoke/default/php_test.rb
@@ -23,4 +23,8 @@ control 'php-1.0' do
   describe package('php7.4-gd') do
     it { should be_installed }
   end
+
+  describe package('php8.0-cli') do
+    it { should be_installed }
+  end
 end


### PR DESCRIPTION
The phive resource was extended with a php_version property so the version can be set explicitly when installing the dependencies. The default is still php-* which will install the latest php version. This can mess with the default version, apache, ... when a specific version is needed.