### PR TITLE
PHPVersion is now passed as package name when installing php

### DIFF
--- a/resources/phive.rb
+++ b/resources/phive.rb
@@ -11,6 +11,7 @@ property :php_version, String, default: 'php', description: 'The desired php ver
 
 action :install do
   codenamephp_php_package 'install needed extensions' do
+    package_name get_dependency_package_names_with_php_version(%w(cli), new_resource.php_version).first
     additional_packages get_dependency_package_names_with_php_version(%w(xml mbstring curl), new_resource.php_version)
     only_if new_resource.install_php_dependencies.to_s
   end

--- a/spec/unit/resources/phive_spec.rb
+++ b/spec/unit/resources/phive_spec.rb
@@ -30,6 +30,7 @@ describe 'codenamephp_php_phive' do
 
     it {
       is_expected.to install_codenamephp_php_package('install needed extensions').with(
+        package_name: 'php-cli',
         additional_packages: %w(php-xml php-mbstring php-curl)
       )
 
@@ -89,6 +90,7 @@ describe 'codenamephp_php_phive' do
 
     it {
       is_expected.to install_codenamephp_php_package('install needed extensions').with(
+        package_name: 'php5.6-cli',
         additional_packages: %w(php5.6-xml php5.6-mbstring php5.6-curl)
       )
 
@@ -133,6 +135,7 @@ describe 'codenamephp_php_phive' do
 
     it {
       is_expected.to install_codenamephp_php_package('install needed extensions').with(
+        package_name: 'php5.6-cli',
         additional_packages: %w(php5.6-xml php5.6-mbstring php5.6-curl)
       )
     }
@@ -152,9 +155,7 @@ describe 'codenamephp_php_phive' do
     end
 
     it {
-      is_expected.to_not install_codenamephp_php_package('install needed extensions').with(
-        additional_packages: %w(php-xml php-mbstring)
-      )
+      is_expected.to_not install_codenamephp_php_package('install needed extensions')
     }
   end
 


### PR DESCRIPTION
Also, the package is now always CLI since this is all phive needs

Fixes #50 